### PR TITLE
Trouble finding the name of the selected command

### DIFF
--- a/README.rdoc
+++ b/README.rdoc
@@ -70,6 +70,8 @@ Assuming a program "prog" with subcommands "del" and "add"
 
     3. call opt_parse()
 
+    selected_command_name = opt_parse()
+
 == Sample Output
 
     $ ruby subcommand.rb help


### PR DESCRIPTION
I had trouble finding the name of the command (I found it by reading one of the tests). This patch simply changes the documentation to make it clear.
