### PR TITLE
Support for appname attribute

### DIFF
--- a/lib/subcommand.rb
+++ b/lib/subcommand.rb
@@ -140,7 +140,7 @@ module Subcommands
       end
     end
   end
-  # first parse global optinos
+  # first parse global options
   # then parse subcommand options if valid subcommand
   # special case of "help command" so we print help of command - git style (3)
   # in all invalid cases print global help

--- a/lib/subcommand.rb
+++ b/lib/subcommand.rb
@@ -56,6 +56,9 @@ class OptionParser
 end
 
 module Subcommands
+
+  attr_accessor :appname
+
   ##
   # specify a single command and all its options
   # If multiple names are given, they are treated as aliases.
@@ -112,7 +115,7 @@ module Subcommands
       @aliases.each_pair { |name, val| cmdtext << "   #{name} - #{val}\n"  }
     end
 
-    cmdtext << "\n\nSee '#{$0} help COMMAND' for more information on a specific command."
+    cmdtext << "\n\nSee '#{appname || $0} help COMMAND' for more information on a specific command."
   end
   ## add text of subcommands in help and --help option
   def add_subcommand_help
@@ -150,7 +153,7 @@ module Subcommands
     @command_name = nil
     if !defined? @global
       global_options do |opts|
-        opts.banner = "Usage: #{$0} [options] [subcommand [options]]"
+        opts.banner = "Usage: #{appname || $0} [options] [subcommand [options]]"
         opts.separator ""
         opts.separator "Global options are:"
         opts.on("-h", "--help", "Print this help") do |v|


### PR DESCRIPTION
In the default help output, the full path of the script was being printed, which was way too noisy.

I added an :appname attribute and used it in the appropriate places.
